### PR TITLE
[Refact] #5 - AuthenticationManager / DaoAuthenticationProvider 기반 로그인 리팩토링

### DIFF
--- a/src/main/java/com/werp/sero/auth/controller/AuthController.java
+++ b/src/main/java/com/werp/sero/auth/controller/AuthController.java
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
     private final AuthService authService;
 
-    @Operation(summary = "본사 직원용 로그인", description = "- email : admin@werp.com\n- password : kang")
+    @Operation(summary = "본사 직원용 로그인", description = "- email : procurement01@hanwha.com\n- password : kang")
     @PostMapping("/auth/login")
     public ResponseEntity<LoginResponseDTO> loginEmployee(@Valid @RequestBody final LoginRequestDTO requestDTO,
                                                           final HttpServletResponse response) {

--- a/src/main/java/com/werp/sero/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/werp/sero/auth/service/AuthServiceImpl.java
@@ -8,11 +8,14 @@ import com.werp.sero.employee.command.domain.aggregate.Employee;
 import com.werp.sero.employee.command.domain.repository.ClientEmployeeRepository;
 import com.werp.sero.employee.command.domain.repository.EmployeeRepository;
 import com.werp.sero.permission.command.domain.repository.EmployeePermissionRepository;
+import com.werp.sero.security.authenticationToken.ClientEmployeeAuthenticationToken;
+import com.werp.sero.security.authenticationToken.EmployeeAuthenticationToken;
 import com.werp.sero.security.dto.JwtToken;
 import com.werp.sero.security.enums.Type;
 import com.werp.sero.security.jwt.JwtTokenProvider;
 import com.werp.sero.security.jwt.exception.InvalidTokenException;
-import com.werp.sero.security.principal.CustomUserDetails;
+import com.werp.sero.security.userdetails.CustomUserDetails;
+import com.werp.sero.security.userdetails.JwtUserDetails;
 import com.werp.sero.util.CookieUtil;
 import com.werp.sero.util.HeaderUtil;
 import com.werp.sero.util.RedisUtil;
@@ -20,9 +23,11 @@ import io.jsonwebtoken.JwtException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -38,30 +43,35 @@ public class AuthServiceImpl implements AuthService {
     private final RedisUtil redisUtil;
     private final CookieUtil cookieUtil;
     private final JwtTokenProvider jwtTokenProvider;
-    private final PasswordEncoder passwordEncoder;
     private final EmployeeRepository employeeRepository;
     private final ClientEmployeeRepository clientEmployeeRepository;
     private final EmployeePermissionRepository employeePermissionRepository;
+    private final AuthenticationManager authenticationManager;
 
     @Transactional
     @Override
     public LoginResponseDTO login(final LoginRequestDTO requestDTO, final HttpServletResponse response,
                                   final Type type) {
-        final CustomUserDetails userDetails =
-                authenticateAndGetUserDetails(requestDTO.getEmail(), requestDTO.getPassword(), type);
+        try {
+            Authentication authenticationToken = (type.equals(Type.EMPLOYEE))
+                    ? new EmployeeAuthenticationToken(requestDTO.getEmail(), requestDTO.getPassword())
+                    : new ClientEmployeeAuthenticationToken(requestDTO.getEmail(), requestDTO.getPassword());
 
-        final Authentication authentication =
-                new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+            authenticationToken = authenticationManager.authenticate(authenticationToken);
 
-        final JwtToken accessToken = jwtTokenProvider.generateAccessToken(authentication);
-        final JwtToken refreshToken = jwtTokenProvider.generateRefreshToken(authentication);
+            final JwtToken accessToken = jwtTokenProvider.generateAccessToken(authenticationToken);
 
-        redisUtil.setData(REFRESH_TOKEN_PREFIX + requestDTO.getEmail(), refreshToken.getToken(),
-                refreshToken.getExpirationTime(), TimeUnit.MILLISECONDS);
+            final JwtToken refreshToken = jwtTokenProvider.generateRefreshToken(authenticationToken);
 
-        cookieUtil.generateRefreshTokenCookie(response, refreshToken);
+            redisUtil.setData(REFRESH_TOKEN_PREFIX + requestDTO.getEmail(), refreshToken.getToken(),
+                    refreshToken.getExpirationTime(), TimeUnit.MILLISECONDS);
 
-        return new LoginResponseDTO(accessToken.getToken(), GRANT_TYPE, accessToken.getAuthorities());
+            cookieUtil.generateRefreshTokenCookie(response, refreshToken);
+
+            return new LoginResponseDTO(accessToken.getToken(), GRANT_TYPE, accessToken.getAuthorities());
+        } catch (InternalAuthenticationServiceException | BadCredentialsException e) {
+            throw new LoginFailedException();
+        }
     }
 
     @Transactional
@@ -113,25 +123,6 @@ public class AuthServiceImpl implements AuthService {
         return new LoginResponseDTO(accessToken.getToken(), GRANT_TYPE, accessToken.getAuthorities());
     }
 
-    private CustomUserDetails authenticateAndGetUserDetails(final String email, final String rawPassword,
-                                                            final Type type) {
-        if (type == Type.EMPLOYEE) {
-            final Employee employee = employeeRepository.findByEmailAndStatus(email, "ES_ACT")
-                    .orElseThrow(LoginFailedException::new);
-
-            matchRawPasswordAndEncodedPassword(rawPassword, employee.getPassword());
-
-            return buildFromEmployee(employee);
-        }
-
-        final ClientEmployee clientEmployee = clientEmployeeRepository.findByEmail(email)
-                .orElseThrow(LoginFailedException::new);
-
-        matchRawPasswordAndEncodedPassword(rawPassword, clientEmployee.getPassword());
-
-        return buildFromClientEmployee(clientEmployee);
-    }
-
     private CustomUserDetails getUserDetailsForReissue(final String email, final Type type) {
         if (type == Type.EMPLOYEE) {
             return buildFromEmployee(employeeRepository.findByEmailAndStatus(email, "ES_ACT")
@@ -144,17 +135,12 @@ public class AuthServiceImpl implements AuthService {
 
     private CustomUserDetails buildFromEmployee(final Employee employee) {
         final List<String> permissions = employeePermissionRepository.findPermissionCodeByEmployee(employee);
-        return new CustomUserDetails(Type.EMPLOYEE, employee.getId(), employee.getEmail(), null, permissions);
+
+        return new JwtUserDetails(employee.getId(), employee.getEmail(), null, Type.EMPLOYEE, permissions);
     }
 
     private CustomUserDetails buildFromClientEmployee(final ClientEmployee clientEmployee) {
-        return new CustomUserDetails(Type.CLIENT_EMPLOYEE, clientEmployee.getId(), clientEmployee.getEmail(),
-                clientEmployee.getClient().getId(), List.of("AC_CLI"));
-    }
-
-    private void matchRawPasswordAndEncodedPassword(final String rawPassword, final String encodedPassword) {
-        if (!passwordEncoder.matches(rawPassword, encodedPassword)) {
-            throw new LoginFailedException();
-        }
+        return new JwtUserDetails(clientEmployee.getId(), clientEmployee.getEmail(), clientEmployee.getClient().getId(),
+                Type.CLIENT_EMPLOYEE, List.of("AC_CLI"));
     }
 }

--- a/src/main/java/com/werp/sero/employee/command/domain/repository/ClientEmployeeRepository.java
+++ b/src/main/java/com/werp/sero/employee/command/domain/repository/ClientEmployeeRepository.java
@@ -2,9 +2,14 @@ package com.werp.sero.employee.command.domain.repository;
 
 import com.werp.sero.employee.command.domain.aggregate.ClientEmployee;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface ClientEmployeeRepository extends JpaRepository<ClientEmployee, Integer> {
     Optional<ClientEmployee> findByEmail(final String email);
+
+    @Query("SELECT A FROM ClientEmployee A JOIN FETCH A.client WHERE A.email = :email")
+    Optional<ClientEmployee> findByEmailFetchJoin(@Param("email") final String email);
 }

--- a/src/main/java/com/werp/sero/security/authenticationToken/ClientEmployeeAuthenticationToken.java
+++ b/src/main/java/com/werp/sero/security/authenticationToken/ClientEmployeeAuthenticationToken.java
@@ -1,0 +1,9 @@
+package com.werp.sero.security.authenticationToken;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+
+public class ClientEmployeeAuthenticationToken extends UsernamePasswordAuthenticationToken {
+    public ClientEmployeeAuthenticationToken(final String email, final String password) {
+        super(email, password);
+    }
+}

--- a/src/main/java/com/werp/sero/security/authenticationToken/EmployeeAuthenticationToken.java
+++ b/src/main/java/com/werp/sero/security/authenticationToken/EmployeeAuthenticationToken.java
@@ -1,0 +1,9 @@
+package com.werp.sero.security.authenticationToken;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+
+public class EmployeeAuthenticationToken extends UsernamePasswordAuthenticationToken {
+    public EmployeeAuthenticationToken(final String email, final String password) {
+        super(email, password);
+    }
+}

--- a/src/main/java/com/werp/sero/security/config/SecurityConfig.java
+++ b/src/main/java/com/werp/sero/security/config/SecurityConfig.java
@@ -1,13 +1,22 @@
 package com.werp.sero.security.config;
 
+import com.werp.sero.employee.command.domain.repository.ClientEmployeeRepository;
+import com.werp.sero.employee.command.domain.repository.EmployeeRepository;
+import com.werp.sero.permission.command.domain.repository.EmployeePermissionRepository;
 import com.werp.sero.security.handler.CustomAccessDeniedHandler;
 import com.werp.sero.security.handler.CustomAuthenticationEntryPoint;
 import com.werp.sero.security.jwt.JwtAuthenticationFilter;
 import com.werp.sero.security.jwt.JwtExceptionFilter;
 import com.werp.sero.security.jwt.JwtTokenProvider;
+import com.werp.sero.security.provider.ClientEmployeeAuthenticationProvider;
+import com.werp.sero.security.provider.EmployeeAuthenticationProvider;
+import com.werp.sero.security.userdetails.ClientEmployeeUserDetailsServiceImpl;
+import com.werp.sero.security.userdetails.EmployeeUserDetailsServiceImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
@@ -46,6 +55,35 @@ public class SecurityConfig {
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
     private final CustomAccessDeniedHandler customAccessDeniedHandler;
     private final CorsConfigurationSource corsConfigurationSource;
+
+    @Bean
+    public ClientEmployeeAuthenticationProvider clientEmployeeAuthenticationProvider(final ClientEmployeeUserDetailsServiceImpl userDetailsService,
+                                                                                     final PasswordEncoder passwordEncoder) {
+        return new ClientEmployeeAuthenticationProvider(userDetailsService, passwordEncoder);
+    }
+
+    @Bean
+    public EmployeeAuthenticationProvider employeeAuthenticationProvider(final EmployeeUserDetailsServiceImpl userDetailsService,
+                                                                         final PasswordEncoder passwordEncoder) {
+        return new EmployeeAuthenticationProvider(userDetailsService, passwordEncoder);
+    }
+
+    @Bean
+    public ClientEmployeeUserDetailsServiceImpl clientEmployeeUserDetailsService(final ClientEmployeeRepository clientEmployeeRepository) {
+        return new ClientEmployeeUserDetailsServiceImpl(clientEmployeeRepository);
+    }
+
+    @Bean
+    public EmployeeUserDetailsServiceImpl EmployeeUserDetailsService(final EmployeeRepository employeeRepository,
+                                                                     final EmployeePermissionRepository employeePermissionRepository) {
+        return new EmployeeUserDetailsServiceImpl(employeeRepository, employeePermissionRepository);
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(final EmployeeAuthenticationProvider employeeAuthenticationProvider,
+                                                       final ClientEmployeeAuthenticationProvider clientEmployeeAuthenticationProvider) {
+        return new ProviderManager(employeeAuthenticationProvider, clientEmployeeAuthenticationProvider);
+    }
 
     @Bean
     public PasswordEncoder passwordEncoder() {

--- a/src/main/java/com/werp/sero/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/werp/sero/security/jwt/JwtTokenProvider.java
@@ -1,10 +1,11 @@
 package com.werp.sero.security.jwt;
 
-import com.werp.sero.security.principal.CustomUserDetails;
+import com.werp.sero.security.userdetails.CustomUserDetails;
 import com.werp.sero.security.dto.JwtToken;
 import com.werp.sero.security.enums.Type;
 import com.werp.sero.security.jwt.exception.ExpiredTokenException;
 import com.werp.sero.security.jwt.exception.InvalidTokenException;
+import com.werp.sero.security.userdetails.JwtUserDetails;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
@@ -50,18 +51,18 @@ public class JwtTokenProvider {
     }
 
     public JwtToken generateAccessToken(final Authentication authentication) {
-        final CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
+        final CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
 
-        final String authorities = authentication.getAuthorities().stream()
+        final String authorities = userDetails.getAuthorities().stream()
                 .map(GrantedAuthority::getAuthority)
                 .collect(Collectors.joining(","));
 
         final String accessToken = Jwts.builder()
-                .subject(customUserDetails.getUsername())
+                .subject(userDetails.getUsername())
                 .claim(AUTHORITIES_KEY, authorities)
-                .claim(TYPE_KEY, customUserDetails.getType().name())
-                .claim(ID_KEY, customUserDetails.getId())
-                .claim(CLIENT_KEY, customUserDetails.getClientId())
+                .claim(TYPE_KEY, userDetails.getType().name())
+                .claim(ID_KEY, userDetails.getId())
+                .claim(CLIENT_KEY, userDetails.getClientId())
                 .expiration(new Date(System.currentTimeMillis() + accessTokenExpirationTime))
                 .signWith(secretKey)
                 .compact();
@@ -119,7 +120,7 @@ public class JwtTokenProvider {
 
         final List<String> permissionList = Arrays.asList(claims.get(AUTHORITIES_KEY).toString().split(","));
 
-        final CustomUserDetails userDetails = new CustomUserDetails(type, id, email, clientId, permissionList);
+        final JwtUserDetails userDetails = new JwtUserDetails(id, email, clientId, type, permissionList);
 
         return new UsernamePasswordAuthenticationToken(userDetails, null, authorities);
     }

--- a/src/main/java/com/werp/sero/security/provider/ClientEmployeeAuthenticationProvider.java
+++ b/src/main/java/com/werp/sero/security/provider/ClientEmployeeAuthenticationProvider.java
@@ -1,0 +1,19 @@
+package com.werp.sero.security.provider;
+
+import com.werp.sero.security.authenticationToken.ClientEmployeeAuthenticationToken;
+import com.werp.sero.security.userdetails.ClientEmployeeUserDetailsServiceImpl;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+public class ClientEmployeeAuthenticationProvider extends DaoAuthenticationProvider {
+    public ClientEmployeeAuthenticationProvider(final ClientEmployeeUserDetailsServiceImpl userDetailsService,
+                                                final PasswordEncoder passwordEncoder) {
+        super(userDetailsService);
+        setPasswordEncoder(passwordEncoder);
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return ClientEmployeeAuthenticationToken.class.isAssignableFrom(authentication);
+    }
+}

--- a/src/main/java/com/werp/sero/security/provider/EmployeeAuthenticationProvider.java
+++ b/src/main/java/com/werp/sero/security/provider/EmployeeAuthenticationProvider.java
@@ -1,0 +1,19 @@
+package com.werp.sero.security.provider;
+
+import com.werp.sero.security.authenticationToken.EmployeeAuthenticationToken;
+import com.werp.sero.security.userdetails.EmployeeUserDetailsServiceImpl;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+public class EmployeeAuthenticationProvider extends DaoAuthenticationProvider {
+    public EmployeeAuthenticationProvider(final EmployeeUserDetailsServiceImpl userDetailsService,
+                                          final PasswordEncoder passwordEncoder) {
+        super(userDetailsService);
+        setPasswordEncoder(passwordEncoder);
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return EmployeeAuthenticationToken.class.isAssignableFrom(authentication);
+    }
+}

--- a/src/main/java/com/werp/sero/security/userdetails/ClientEmployeeUserDetails.java
+++ b/src/main/java/com/werp/sero/security/userdetails/ClientEmployeeUserDetails.java
@@ -1,0 +1,52 @@
+package com.werp.sero.security.userdetails;
+
+import com.werp.sero.employee.command.domain.aggregate.ClientEmployee;
+import com.werp.sero.security.enums.Type;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ClientEmployeeUserDetails implements CustomUserDetails {
+    private final ClientEmployee clientEmployee;
+    private final List<String> permissions;
+
+    protected ClientEmployeeUserDetails(final ClientEmployee clientEmployee, final List<String> permissions) {
+        this.clientEmployee = clientEmployee;
+        this.permissions = permissions;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return permissions.stream()
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public String getPassword() {
+        return clientEmployee.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return clientEmployee.getEmail();
+    }
+
+    @Override
+    public int getId() {
+        return this.clientEmployee.getId();
+    }
+
+    @Override
+    public Type getType() {
+        return Type.CLIENT_EMPLOYEE;
+    }
+
+    @Override
+    public Integer getClientId() {
+        return this.clientEmployee.getClient().getId();
+    }
+}

--- a/src/main/java/com/werp/sero/security/userdetails/ClientEmployeeUserDetailsServiceImpl.java
+++ b/src/main/java/com/werp/sero/security/userdetails/ClientEmployeeUserDetailsServiceImpl.java
@@ -1,0 +1,26 @@
+package com.werp.sero.security.userdetails;
+
+import com.werp.sero.employee.command.domain.aggregate.ClientEmployee;
+import com.werp.sero.employee.command.domain.repository.ClientEmployeeRepository;
+import com.werp.sero.employee.command.exception.ClientEmployeeNotFoundException;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+import java.util.List;
+
+public class ClientEmployeeUserDetailsServiceImpl implements UserDetailsService {
+    private final ClientEmployeeRepository clientEmployeeRepository;
+
+    public ClientEmployeeUserDetailsServiceImpl(final ClientEmployeeRepository clientEmployeeRepository) {
+        this.clientEmployeeRepository = clientEmployeeRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(final String username) throws UsernameNotFoundException {
+        final ClientEmployee clientEmployee = clientEmployeeRepository.findByEmailFetchJoin(username)
+                .orElseThrow(ClientEmployeeNotFoundException::new);
+
+        return new ClientEmployeeUserDetails(clientEmployee, List.of("AC_CLI"));
+    }
+}

--- a/src/main/java/com/werp/sero/security/userdetails/CustomUserDetails.java
+++ b/src/main/java/com/werp/sero/security/userdetails/CustomUserDetails.java
@@ -1,0 +1,12 @@
+package com.werp.sero.security.userdetails;
+
+import com.werp.sero.security.enums.Type;
+import org.springframework.security.core.userdetails.UserDetails;
+
+public interface CustomUserDetails extends UserDetails {
+    int getId();
+
+    Type getType();
+
+    Integer getClientId();
+}

--- a/src/main/java/com/werp/sero/security/userdetails/EmployeeUserDetails.java
+++ b/src/main/java/com/werp/sero/security/userdetails/EmployeeUserDetails.java
@@ -1,0 +1,52 @@
+package com.werp.sero.security.userdetails;
+
+import com.werp.sero.employee.command.domain.aggregate.Employee;
+import com.werp.sero.security.enums.Type;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class EmployeeUserDetails implements CustomUserDetails {
+    private final Employee employee;
+    private final List<String> permissions;
+
+    protected EmployeeUserDetails(final Employee employee, final List<String> permissions) {
+        this.employee = employee;
+        this.permissions = permissions;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return permissions.stream()
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public String getPassword() {
+        return this.employee.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return this.employee.getEmail();
+    }
+
+    @Override
+    public int getId() {
+        return this.employee.getId();
+    }
+
+    @Override
+    public Type getType() {
+        return Type.EMPLOYEE;
+    }
+
+    @Override
+    public Integer getClientId() {
+        return null;
+    }
+}

--- a/src/main/java/com/werp/sero/security/userdetails/EmployeeUserDetailsServiceImpl.java
+++ b/src/main/java/com/werp/sero/security/userdetails/EmployeeUserDetailsServiceImpl.java
@@ -1,0 +1,32 @@
+package com.werp.sero.security.userdetails;
+
+import com.werp.sero.employee.command.domain.aggregate.Employee;
+import com.werp.sero.employee.command.domain.repository.EmployeeRepository;
+import com.werp.sero.employee.command.exception.EmployeeNotFoundException;
+import com.werp.sero.permission.command.domain.repository.EmployeePermissionRepository;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+import java.util.List;
+
+public class EmployeeUserDetailsServiceImpl implements UserDetailsService {
+    private final EmployeeRepository employeeRepository;
+    private final EmployeePermissionRepository employeePermissionRepository;
+
+    public EmployeeUserDetailsServiceImpl(final EmployeeRepository employeeRepository,
+                                             final EmployeePermissionRepository employeePermissionRepository) {
+        this.employeeRepository = employeeRepository;
+        this.employeePermissionRepository = employeePermissionRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        final Employee employee = employeeRepository.findByEmailAndStatus(username, "ES_ACT")
+                .orElseThrow(EmployeeNotFoundException::new);
+
+        final List<String> permissions = employeePermissionRepository.findPermissionCodeByEmployee(employee);
+
+        return new EmployeeUserDetails(employee, permissions);
+    }
+}

--- a/src/main/java/com/werp/sero/security/userdetails/JwtUserDetails.java
+++ b/src/main/java/com/werp/sero/security/userdetails/JwtUserDetails.java
@@ -1,27 +1,26 @@
-package com.werp.sero.security.principal;
+package com.werp.sero.security.userdetails;
 
 import com.werp.sero.security.enums.Type;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class CustomUserDetails implements UserDetails {
+public class JwtUserDetails implements CustomUserDetails {
     private final int id;
     private final String email;
-    private final Type type;
     private final Integer clientId;
+    private final Type type;
     private final List<String> permissions;
 
-    public CustomUserDetails(final Type type, final int id, final String email, final Integer clientId,
-                             final List<String> permissions) {
-        this.type = type;
+    public JwtUserDetails(final int id, final String email, final Integer clientId, final Type type,
+                          final List<String> permissions) {
         this.id = id;
         this.email = email;
         this.clientId = clientId;
+        this.type = type;
         this.permissions = permissions;
     }
 
@@ -42,18 +41,17 @@ public class CustomUserDetails implements UserDetails {
         return this.email;
     }
 
-    public Type getType() {
-        return this.type;
-    }
-
+    @Override
     public int getId() {
         return this.id;
     }
 
-    public boolean isEmployee() {
-        return this.type == Type.EMPLOYEE;
+    @Override
+    public Type getType() {
+        return this.type;
     }
 
+    @Override
     public Integer getClientId() {
         return this.clientId;
     }


### PR DESCRIPTION
## Pull Request
### ISSUE
- #5 

### Develop
- UsernamePasswordAuthenticationToken 상속한 유저 타입별 커스텀 토큰 구현 (Employee, ClientEmployee)
- DaoAuthenticationProvider 상속 및 supports()로 다중 Provider 구현
- UserDetailsService / UserDetails 유저 타입별 분리
- 로그인 시 직접 비밀번호 비교 제거 → authenticationManager.authenticate() 위임

### Test
테스트에 대한 설명을 작성해주세요
